### PR TITLE
Add Reserve button and adjust listing heights

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -121,8 +121,15 @@ const Home = () => {
             <img
               src={listing.img}
               alt={listing.title}
-              onError={(e) => (e.target.src = 'https://atlashomestorage.blob.core.windows.net/listing-images/fallback.jpeg')}
-              style={{ width: '100%', borderRadius: '0.5rem', height: '320px', objectFit: 'cover' }}
+              onError={(e) =>
+                (e.target.src =
+                  'https://atlashomestorage.blob.core.windows.net/listing-images/fallback.jpeg')}
+              style={{
+                width: '100%',
+                borderRadius: '0.5rem',
+                height: listing.title === 'Penthouse 501' ? '450px' : '320px',
+                objectFit: 'cover'
+              }}
             />
             <h2 style={{ fontSize: '1.25rem', margin: '0.75rem 0 0.5rem' }}>{listing.title}</h2>
             <p style={{ fontSize: '0.95rem', color: '#555' }}>{listing.desc}</p>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -122,10 +122,16 @@ const Home = () => {
               src={listing.img}
               alt={listing.title}
               onError={(e) => (e.target.src = 'https://atlashomestorage.blob.core.windows.net/listing-images/fallback.jpeg')}
-              style={{ width: '100%', borderRadius: '0.5rem', height: '200px', objectFit: 'cover' }}
+              style={{ width: '100%', borderRadius: '0.5rem', height: '250px', objectFit: 'cover' }}
             />
             <h2 style={{ fontSize: '1.25rem', margin: '0.75rem 0 0.5rem' }}>{listing.title}</h2>
             <p style={{ fontSize: '0.95rem', color: '#555' }}>{listing.desc}</p>
+            <button
+              className="btn btn-danger"
+              style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F', marginTop: 'auto' }}
+            >
+              Reserve
+            </button>
           </div>
         ))}
       </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -122,7 +122,7 @@ const Home = () => {
               src={listing.img}
               alt={listing.title}
               onError={(e) => (e.target.src = 'https://atlashomestorage.blob.core.windows.net/listing-images/fallback.jpeg')}
-              style={{ width: '100%', borderRadius: '0.5rem', height: '250px', objectFit: 'cover' }}
+              style={{ width: '100%', borderRadius: '0.5rem', height: '320px', objectFit: 'cover' }}
             />
             <h2 style={{ fontSize: '1.25rem', margin: '0.75rem 0 0.5rem' }}>{listing.title}</h2>
             <p style={{ fontSize: '0.95rem', color: '#555' }}>{listing.desc}</p>

--- a/src/pages/ListingDetails.jsx
+++ b/src/pages/ListingDetails.jsx
@@ -15,11 +15,17 @@ const ListingDetails = () => {
 
     return (
         <div className="card">
-            <img src="https://via.placeholder.com/800x400?text=Listing" className="card-img-top" alt={listing.name} />
-            <div className="card-body">
+            <img
+                src="https://via.placeholder.com/800x400?text=Listing"
+                className="card-img-top"
+                alt={listing.name}
+                style={{ height: '500px', objectFit: 'cover' }}
+            />
+            <div className="card-body d-flex flex-column">
                 <h3 className="card-title">{listing.name}</h3>
                 <p className="card-text">Type: {listing.type}</p>
                 <p className="card-text">Max Guests: {listing.maxGuests}</p>
+                <button className="btn btn-danger mt-auto" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
             </div>
         </div>
     );

--- a/src/pages/ListingDetails.jsx
+++ b/src/pages/ListingDetails.jsx
@@ -19,7 +19,7 @@ const ListingDetails = () => {
                 src="https://via.placeholder.com/800x400?text=Listing"
                 className="card-img-top"
                 alt={listing.name}
-                style={{ height: '500px', objectFit: 'cover' }}
+                style={{ height: '625px', objectFit: 'cover' }}
             />
             <div className="card-body d-flex flex-column">
                 <h3 className="card-title">{listing.name}</h3>

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -15,11 +15,17 @@ const Listings = () => {
             {listings.map(listing => (
                 <div className="col-md-4 mb-4" key={listing.id}>
                     <div className="card h-100">
-                        <img src="https://via.placeholder.com/400x300?text=Listing" className="card-img-top" alt={listing.name} />
+                        <img
+                            src="https://via.placeholder.com/400x300?text=Listing"
+                            className="card-img-top"
+                            alt={listing.name}
+                            style={{ height: '375px', objectFit: 'cover' }}
+                        />
                         <div className="card-body d-flex flex-column">
                             <h5 className="card-title">{listing.name}</h5>
                             <p className="card-text">Sleeps {listing.maxGuests} guests</p>
                             <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
+                            <button className="btn btn-danger mt-2" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
                         </div>
                     </div>
                 </div>

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -19,7 +19,7 @@ const Listings = () => {
                             src="https://via.placeholder.com/400x300?text=Listing"
                             className="card-img-top"
                             alt={listing.name}
-                            style={{ height: '375px', objectFit: 'cover' }}
+                            style={{ height: '470px', objectFit: 'cover' }}
                         />
                         <div className="card-body d-flex flex-column">
                             <h5 className="card-title">{listing.name}</h5>

--- a/src/style.css
+++ b/src/style.css
@@ -33,6 +33,8 @@ body {
     padding: 1rem;
     border-radius: 0.75rem;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
 }
 
 .listings .card:first-child {


### PR DESCRIPTION
## Summary
- add red Reserve button to Home page listings
- enlarge listing images on Home page
- increase listing image height on listings page and add Reserve button
- enlarge image and add Reserve button on listing detail page
- ensure Reserve button sits at bottom of Home page cards

## Testing
- `npm install --force`
- `node node_modules/vite/bin/vite.js build`

------
https://chatgpt.com/codex/tasks/task_e_68578ca222a4832bacc6cb59c3bc80ef