### PR TITLE
feat: refresh portal branding and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <title>Atlas Homestays</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="root"></div>

--- a/src/components/chrome/Footer.jsx
+++ b/src/components/chrome/Footer.jsx
@@ -6,12 +6,21 @@ export default function Footer() {
       <div className="ftr__wrap">
         <div>© {new Date().getFullYear()} Atlas Homestays • Hyderabad</div>
         <div className="ftr__links">
-          <a href="/policies">Policies</a>
-          <a href={SOCIAL.instagram} target="_blank" rel="noreferrer">Instagram</a>
-          <a href={SOCIAL.facebook} target="_blank" rel="noreferrer">Facebook</a>
-          <a href={SOCIAL.whatsapp}>WhatsApp</a>
-          <a href={SOCIAL.phone}>Call</a>
-          <a href={SOCIAL.email}>Email</a>
+          <a href={SOCIAL.instagram} target="_blank" rel="noreferrer" aria-label="Instagram" className="icon-btn">
+            <i className="fa-brands fa-instagram"></i>
+          </a>
+          <a href={SOCIAL.facebook} target="_blank" rel="noreferrer" aria-label="Facebook" className="icon-btn">
+            <i className="fa-brands fa-facebook"></i>
+          </a>
+          <a href={SOCIAL.whatsapp} aria-label="WhatsApp" className="icon-btn whatsapp">
+            <i className="fa-brands fa-whatsapp"></i>
+          </a>
+          <a href={SOCIAL.phone} aria-label="Call" className="icon-btn">
+            <i className="fa-solid fa-phone"></i>
+          </a>
+          <a href={SOCIAL.email} aria-label="Email" className="icon-btn">
+            <i className="fa-solid fa-envelope"></i>
+          </a>
         </div>
       </div>
     </footer>

--- a/src/components/chrome/Header.jsx
+++ b/src/components/chrome/Header.jsx
@@ -11,9 +11,21 @@ export default function Header() {
           <a href="#contact">Contact</a>
         </nav>
         <div className="hdr__actions">
-          <a href={SOCIAL.whatsapp}>WhatsApp</a>
-          <a href={SOCIAL.phone}>Call</a>
-          <a href={SOCIAL.email}>Email</a>
+          <a href={SOCIAL.instagram} target="_blank" rel="noreferrer" aria-label="Instagram" className="icon-btn">
+            <i className="fa-brands fa-instagram"></i>
+          </a>
+          <a href={SOCIAL.facebook} target="_blank" rel="noreferrer" aria-label="Facebook" className="icon-btn">
+            <i className="fa-brands fa-facebook"></i>
+          </a>
+          <a href={SOCIAL.whatsapp} aria-label="WhatsApp" className="icon-btn whatsapp">
+            <i className="fa-brands fa-whatsapp"></i>
+          </a>
+          <a href={SOCIAL.phone} aria-label="Call" className="icon-btn">
+            <i className="fa-solid fa-phone"></i>
+          </a>
+          <a href={SOCIAL.email} aria-label="Email" className="icon-btn">
+            <i className="fa-solid fa-envelope"></i>
+          </a>
         </div>
       </div>
     </header>

--- a/src/components/listings/ListingCard.jsx
+++ b/src/components/listings/ListingCard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import PopoverPortal from '../shared/PopoverPortal';
 import { useOnClickOutside, useOnEsc } from '../../hooks/useOnClickOutside';
 import { DayPicker } from 'react-day-picker';
@@ -63,7 +64,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
       </div>
       <div className="lc-body">
         <div className="lc-header">
-          <h3 className="lc-title">{listing.title}</h3>
+          <h3 className="lc-title"><Link to={`/listings/${listing.id}`}>{listing.title}</Link></h3>
           <div className="lc-sub">{listing.location}</div>
           <div className="lc-price">₹{listing.pricePerNight} / night</div>
         </div>
@@ -94,20 +95,21 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
           </div>
 
           <div className="lc-actions">
-            <button className="btn-primary" onClick={() => setOpenEnquiry(true)}>
+            <button className="btn-dark" onClick={() => setOpenEnquiry(true)}>
               Enquire Now
             </button>
-            <a className="btn-ghost" href={whatsappLink} target="_blank" rel="noreferrer">
-              WhatsApp
+            <a className="icon-btn whatsapp" href={whatsappLink} target="_blank" rel="noreferrer" aria-label="WhatsApp">
+              <i className="fa-brands fa-whatsapp"></i>
             </a>
-            <a className="btn-ghost" href={`tel:${CONTACT.phoneE164}`}>
-              Call
+            <a className="icon-btn" href={`tel:${CONTACT.phoneE164}`} aria-label="Call">
+              <i className="fa-solid fa-phone"></i>
             </a>
             <a
-              className="btn-ghost"
+              className="icon-btn"
               href={`mailto:${CONTACT.email}?subject=${encodeURIComponent('Enquiry: ' + listing.title)}`}
+              aria-label="Email"
             >
-              Email
+              <i className="fa-solid fa-envelope"></i>
             </a>
           </div>
         </div>

--- a/src/components/shared/ContactStrip.jsx
+++ b/src/components/shared/ContactStrip.jsx
@@ -1,11 +1,13 @@
-import { CONTACT } from '../../config/siteConfig';
+import React from 'react';
 
-export default function ContactStrip() {
+export default function ContactStrip({ price, whatsappLink, onEnquire }) {
   return (
     <div className="contact-strip">
-      <a href={`https://wa.me/${CONTACT.whatsappE164.replace('+','')}`} target="_blank" rel="noreferrer">WhatsApp</a>
-      <a href={`tel:${CONTACT.phoneE164}`}>Call</a>
-      <a href={`mailto:${CONTACT.email}`}>Email</a>
+      <div className="price">₹{price} / night</div>
+      <button className="btn-dark" onClick={onEnquire}>Enquire Now</button>
+      <a href={whatsappLink} target="_blank" rel="noreferrer" aria-label="WhatsApp" className="icon-btn whatsapp">
+        <i className="fa-brands fa-whatsapp"></i>
+      </a>
     </div>
   );
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,8 +1,8 @@
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
-import ContactStrip from './components/shared/ContactStrip';
 import Header from './components/chrome/Header';
 import Footer from './components/chrome/Footer';
+import ListingDetails from './pages/ListingDetails';
 
 export default function AppRoutes() {
   return (
@@ -10,9 +10,9 @@ export default function AppRoutes() {
       <Header />
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/listings/:id" element={<ListingDetails />} />
       </Routes>
       <Footer />
-      {typeof window !== 'undefined' && window.innerWidth < 768 && <ContactStrip />}
     </>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,10 @@
+:root {
+    --color-primary: #4F46E5;
+    --color-accent: #10B981;
+}
+
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Inter', sans-serif;
 }
 
 .site-header {
@@ -33,11 +38,12 @@ body {
 }
 
 /* ListingCard internals */
-.card .lc-card { background:#fff; border:1px solid #eee; border-radius:12px; box-shadow:0 1px 4px rgba(0,0,0,.04); }
+.card .lc-card { background:#fff; border:1px solid #eee; border-radius:12px; box-shadow:0 1px 4px rgba(0,0,0,.04); overflow:hidden; }
 .lc-media { position:relative; aspect-ratio:16/9; overflow:hidden; }
 .lc-media img { width:100%; height:100%; object-fit:cover; display:block; }
 .lc-body { padding:14px; }
 .lc-title { margin:0 0 2px; font-weight:600; font-size:1.12rem; }
+.lc-title a { color:inherit; text-decoration:none; }
 .lc-sub { color:#6b7280; font-size:.92rem; }
 .lc-price { margin-top:6px; font-weight:600; }
 
@@ -47,12 +53,18 @@ body {
 .lc-select { height:36px; padding:0 10px; }
 .lc-pill { padding:4px 10px; border-radius:999px; font-size:.85rem; justify-self:end; white-space:nowrap; }
 .lc-pill.muted { background:#f3f4f6; color:#6b7280; }
-.lc-pill.ok { background:#ecfdf5; color:#065f46; }
+.lc-pill.ok { background:#d1fae5; color:#065f46; }
 
 .lc-actions { display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end; margin-top:8px; }
-.btn-primary { height:36px; padding:0 14px; border-radius:8px; border:none; background:#111827; color:#fff; font-weight:600; }
-.btn-primary:focus-visible { outline:2px solid #11182744; outline-offset:2px; }
+.btn-primary { height:36px; padding:0 14px; border-radius:8px; border:none; background:var(--color-primary); color:#fff; font-weight:600; }
+.btn-primary:focus-visible { outline:2px solid #4F46E544; outline-offset:2px; }
 .btn-primary:disabled { opacity:.5; cursor:not-allowed; }
+.btn-dark { height:36px; padding:0 14px; border-radius:8px; border:none; background:#111827; color:#fff; font-weight:600; }
+.btn-dark:focus-visible { outline:2px solid #11182744; outline-offset:2px; }
+.btn-dark:disabled { opacity:.5; cursor:not-allowed; }
+.icon-btn { width:36px; height:36px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; display:flex; align-items:center; justify-content:center; color:var(--color-primary); text-decoration:none; font-size:18px; }
+.icon-btn:hover { background:#f9fafb; }
+.icon-btn.whatsapp { color:var(--color-accent); }
 .btn-ghost { height:32px; padding:0 10px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; text-decoration:none; display:flex; align-items:center; font-size:.85rem; }
 .btn-ghost:hover { background:#f9fafb; }
 
@@ -116,19 +128,23 @@ body {
 .modal-actions { display:flex; gap:8px; justify-content:flex-end; margin-top:8px; }
 .success { margin-top:8px; color:#065f46; background:#ecfdf5; padding:8px; border-radius:8px; font-size:.9rem; }
 @media (max-width: 768px) {
-  .contact-strip { position:fixed; bottom:0; left:0; right:0; display:flex; justify-content:space-around; background:#111827; color:#fff; padding:10px; z-index:40; }
-  .contact-strip a { color:#fff; text-decoration:none; font-weight:600; }
-  body { padding-bottom:56px; }
+  .contact-strip { position:fixed; bottom:0; left:0; right:0; display:flex; align-items:center; gap:12px; background:#fff; padding:10px 16px; box-shadow:0 -2px 5px rgba(0,0,0,.1); z-index:40; }
+  .contact-strip .price { font-weight:600; }
+  .contact-strip .btn-dark { flex:1; }
+  body { padding-bottom:72px; }
 }
 
 .hdr { position:sticky; top:0; z-index:900; background:#fff; border-bottom:1px solid #eee; }
 .hdr__wrap { max-width:1120px; margin:0 auto; padding:10px 16px; display:flex; gap:12px; align-items:center; justify-content:space-between; }
-.brand { font-weight:700; }
+.brand { font-weight:700; color:var(--color-primary); }
 .nav a { margin:0 8px; color:#374151; text-decoration:none; }
-.hdr__actions a { margin-left:10px; text-decoration:none; }
+.hdr__actions { display:flex; gap:10px; }
+
+.hdr__actions .icon-btn { border:none; background:transparent; color:#4b5563; }
+.hdr__actions .icon-btn:hover { color:#111827; }
 
 .ftr { background:#111827; color:#fff; margin-top:32px; }
 .ftr__wrap { max-width:1120px; margin:0 auto; padding:16px; display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; }
 .ftr__links { display:flex; gap:16px; }
-.ftr__links a { color:#9ca3af; text-decoration:none; font-size:.9rem; }
-.ftr__links a:hover { color:#fff; }
+.ftr__links .icon-btn { border:none; background:transparent; color:#9ca3af; }
+.ftr__links .icon-btn:hover { color:#fff; }


### PR DESCRIPTION
## Summary
- revamp header and footer with branded icon links and Inter typography
- convert listing cards to icon contact actions and add sticky mobile enquiry bar
- add listing detail route with mobile price bar and modern color variables

## Testing
- `node node_modules/vite/bin/vite.js build`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a04f29a58c832bad841de0f8322e97