### PR TITLE
Fetch listing details from API and add trust indicators

### DIFF
--- a/src/pages/ListingDetails.jsx
+++ b/src/pages/ListingDetails.jsx
@@ -1,16 +1,24 @@
 import { useParams } from 'react-router-dom';
-import { useState } from 'react';
-import { getListingById } from '../data/listings';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { API_BASE } from '../config';
 import { CONTACT } from '../config/siteConfig';
 import EnquiryModal from '../components/shared/EnquiryModal';
 import ContactStrip from '../components/shared/ContactStrip';
 
 export default function ListingDetails() {
   const { id } = useParams();
-  const listing = getListingById(id);
+  const [listing, setListing] = useState(null);
   const [openEnquiry, setOpenEnquiry] = useState(false);
+  const [imageIndex, setImageIndex] = useState(0);
 
-  if (!listing) return <p>Listing not found.</p>;
+  useEffect(() => {
+    axios.get(`${API_BASE}/listings/${id}`).then(res => {
+      setListing(res.data);
+    });
+  }, [id]);
+
+  if (!listing) return <p>Loading...</p>;
 
   const whatsappLink = (() => {
     const msg = encodeURIComponent(
@@ -21,13 +29,65 @@ export default function ListingDetails() {
 
   return (
     <div className="card">
-      <div className="lc-media">
-        <img src={listing.imageUrl} alt={listing.title} />
+      <div className="lc-media position-relative">
+        {(() => {
+          const images = listing.images || listing.imageUrls || [listing.imageUrl];
+          const handleImageError = (e) => {
+            e.target.src = '/hero.jpg';
+          };
+          const prev = () => setImageIndex((imageIndex - 1 + images.length) % images.length);
+          const next = () => setImageIndex((imageIndex + 1) % images.length);
+          return (
+            <>
+              <img
+                src={images[imageIndex]}
+                alt={`${listing.title} image ${imageIndex + 1}`}
+                loading="lazy"
+                onError={handleImageError}
+              />
+              {images.length > 1 && (
+                <>
+                  <button className="carousel-control-prev" onClick={prev}>
+                    ‹
+                  </button>
+                  <button className="carousel-control-next" onClick={next}>
+                    ›
+                  </button>
+                </>
+              )}
+            </>
+          );
+        })()}
       </div>
       <div className="lc-body d-flex flex-column">
         <h3 className="lc-title">{listing.title}</h3>
         <div className="lc-sub">{listing.location}</div>
-        <div className="lc-price">₹{listing.pricePerNight} / night</div>
+        {listing.pricePerNight || listing.price ? (
+          <div className="lc-price">₹{listing.pricePerNight || listing.price} / night</div>
+        ) : null}
+        {listing.rating && <div className="lc-rating">Rating: {listing.rating}</div>}
+        {listing.amenities && listing.amenities.length > 0 && (
+          <div className="lc-amenities mt-3">
+            <h5>Amenities</h5>
+            <ul>
+              {listing.amenities.map((am) => (
+                <li key={am}>{am}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {listing.cancellationPolicy && (
+          <div className="lc-cancellation mt-3">
+            <h5>Cancellation Policy</h5>
+            <p>{listing.cancellationPolicy}</p>
+          </div>
+        )}
+        {listing.reviewScore && (
+          <div className="lc-review mt-3">
+            <h5>Review Score</h5>
+            <p>{listing.reviewScore}</p>
+          </div>
+        )}
       </div>
       {openEnquiry && (
         <EnquiryModal

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -10,20 +10,31 @@ const Listings = () => {
         axios.get(`${API_BASE}/listings`).then(res => setListings(res.data));
     }, []);
 
+    const handleImageError = (e) => {
+        e.target.src = '/hero.jpg';
+    };
+
     return (
         <div className="row">
             {listings.map(listing => (
                 <div className="col-md-4 mb-4" key={listing.id}>
                     <div className="card h-100">
                         <img
-                            src="https://via.placeholder.com/400x300?text=Listing"
+                            src={listing.imageUrl}
                             className="card-img-top"
-                            alt={listing.name}
+                            alt={listing.name || listing.title}
+                            loading="lazy"
+                            onError={handleImageError}
                             style={{ height: '470px', objectFit: 'cover' }}
                         />
                         <div className="card-body d-flex flex-column">
-                            <h5 className="card-title">{listing.name}</h5>
-                            <p className="card-text">Sleeps {listing.maxGuests} guests</p>
+                            <h5 className="card-title">{listing.name || listing.title}</h5>
+                            {listing.pricePerNight || listing.price ? (
+                                <p className="card-text">₹{listing.pricePerNight || listing.price} / night</p>
+                            ) : null}
+                            {listing.rating ? (
+                                <p className="card-text">Rating: {listing.rating}</p>
+                            ) : null}
                             <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
                             <button className="btn btn-danger mt-2" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
                         </div>


### PR DESCRIPTION
## Summary
- Load listing images and metadata from the API and display price and rating on the listings overview
- Use a lazy-loaded image carousel with fallback imagery and show amenities, cancellation policy, and review score in listing details

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a0541bce28832b903107c7eee0d8d3