### PR TITLE
feat: improve date selection for listings

### DIFF
--- a/src/components/listings/ListingCard.jsx
+++ b/src/components/listings/ListingCard.jsx
@@ -6,6 +6,7 @@ import { DayPicker } from 'react-day-picker';
 import { format } from 'date-fns';
 import EnquiryModal from '../shared/EnquiryModal';
 import { CONTACT } from '../../config/siteConfig';
+import { fetchAvailability } from '../../services/availability';
 
 export default function ListingCard({ listing, prefillDates, prefillGuests }) {
   const [openCal, setOpenCal] = useState(false);
@@ -17,6 +18,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
   const [range, setRange] = useState(prefillDates || { from: null, to: null });
   const [guests, setGuests] = useState(prefillGuests || 1);
   const [openEnquiry, setOpenEnquiry] = useState(false);
+  const [disabledDates, setDisabledDates] = useState([]);
 
   const [coords, setCoords] = useState({ top: 0, left: 0, width: 320 });
   useEffect(() => {
@@ -40,6 +42,14 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
     }
   }, [openCal]);
 
+  useEffect(() => {
+    if (openCal && !disabledDates.length) {
+      fetchAvailability(listing.id)
+        .then(d => setDisabledDates(d.map(dt => new Date(dt))))
+        .catch(() => {});
+    }
+  }, [openCal, listing.id, disabledDates.length]);
+
   const preferredLabel = range.from && range.to
     ? `${format(range.from,'dd MMM')} → ${format(range.to,'dd MMM')}`
     : '';
@@ -56,6 +66,8 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
 
 
   const hasPref = range.from && range.to;
+  const guideText = !range.from ? 'Select check-in date' : !range.to ? 'Select check-out date' : '';
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
   return (
     <div className="lc-card">
@@ -117,9 +129,55 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
 
       {openCal && (
         <PopoverPortal>
-          <div ref={popRef} className="popover" style={{ top: coords.top, left: coords.left, width: coords.width }}>
-            <DayPicker mode="range" selected={range} onSelect={setRange} />
-          </div>
+          {isMobile ? (
+            <div className="cal-backdrop" onClick={() => setOpenCal(false)}>
+              <div
+                ref={popRef}
+                className="cal-sheet"
+                onClick={e => e.stopPropagation()}
+              >
+                <div className="dp-header">
+                  <div className="dp-guide">{guideText}</div>
+                  <button
+                    className="dp-clear"
+                    onClick={() => setRange({ from: null, to: null })}
+                    disabled={!range.from && !range.to}
+                  >
+                    Clear dates
+                  </button>
+                </div>
+                <DayPicker
+                  mode="range"
+                  selected={range}
+                  onSelect={setRange}
+                  disabled={disabledDates}
+                />
+              </div>
+            </div>
+          ) : (
+            <div
+              ref={popRef}
+              className="popover"
+              style={{ top: coords.top, left: coords.left, width: coords.width }}
+            >
+              <div className="dp-header">
+                <div className="dp-guide">{guideText}</div>
+                <button
+                  className="dp-clear"
+                  onClick={() => setRange({ from: null, to: null })}
+                  disabled={!range.from && !range.to}
+                >
+                  Clear dates
+                </button>
+              </div>
+              <DayPicker
+                mode="range"
+                selected={range}
+                onSelect={setRange}
+                disabled={disabledDates}
+              />
+            </div>
+          )}
         </PopoverPortal>
       )}
 

--- a/src/components/search/StickyDateBar.jsx
+++ b/src/components/search/StickyDateBar.jsx
@@ -4,8 +4,9 @@ import { useOnClickOutside, useOnEsc } from '../../hooks/useOnClickOutside';
 import { format } from 'date-fns';
 import { DayPicker } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';
+import { fetchAvailability } from '../../services/availability';
 
-export default function StickyDateBar({ onSearch, initialDates, initialGuests }) {
+export default function StickyDateBar({ onSearch, initialDates, initialGuests, listingId }) {
   const [open, setOpen] = useState(false);
   const btnRef = useRef(null);
   const popRef = useRef(null);
@@ -14,6 +15,7 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
 
   const [range, setRange] = useState(initialDates || { from: null, to: null });
   const [guests, setGuests] = useState(initialGuests || 1);
+  const [disabledDates, setDisabledDates] = useState([]);
 
   const [coords, setCoords] = useState({ top: 0, left: 0, width: 320 });
   useEffect(() => {
@@ -31,9 +33,19 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
     };
   }, [open]);
 
+  useEffect(() => {
+    if (open && listingId && !disabledDates.length) {
+      fetchAvailability(listingId)
+        .then(d => setDisabledDates(d.map(dt => new Date(dt))))
+        .catch(() => {});
+    }
+  }, [open, listingId, disabledDates.length]);
+
   const label = range.from && range.to
     ? `${format(range.from,'dd MMM')} → ${format(range.to,'dd MMM')}`
     : 'Preferred dates';
+  const guideText = !range.from ? 'Select check-in date' : !range.to ? 'Select check-out date' : '';
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
   return (
     <div className="sb-wrap">
@@ -48,9 +60,55 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
       </button>
       {open && (
         <PopoverPortal>
-          <div ref={popRef} className="popover" style={{ top: coords.top, left: coords.left, width: coords.width }}>
-            <DayPicker mode="range" selected={range} onSelect={setRange} />
-          </div>
+          {isMobile ? (
+            <div className="cal-backdrop" onClick={() => setOpen(false)}>
+              <div
+                ref={popRef}
+                className="cal-sheet"
+                onClick={e => e.stopPropagation()}
+              >
+                <div className="dp-header">
+                  <div className="dp-guide">{guideText}</div>
+                  <button
+                    className="dp-clear"
+                    onClick={() => setRange({ from: null, to: null })}
+                    disabled={!range.from && !range.to}
+                  >
+                    Clear dates
+                  </button>
+                </div>
+                <DayPicker
+                  mode="range"
+                  selected={range}
+                  onSelect={setRange}
+                  disabled={disabledDates}
+                />
+              </div>
+            </div>
+          ) : (
+            <div
+              ref={popRef}
+              className="popover"
+              style={{ top: coords.top, left: coords.left, width: coords.width }}
+            >
+              <div className="dp-header">
+                <div className="dp-guide">{guideText}</div>
+                <button
+                  className="dp-clear"
+                  onClick={() => setRange({ from: null, to: null })}
+                  disabled={!range.from && !range.to}
+                >
+                  Clear dates
+                </button>
+              </div>
+              <DayPicker
+                mode="range"
+                selected={range}
+                onSelect={setRange}
+                disabled={disabledDates}
+              />
+            </div>
+          )}
         </PopoverPortal>
       )}
       <select className="sb-select" value={guests} onChange={e => setGuests(Number(e.target.value))}>

--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -1,0 +1,6 @@
+import api from './api';
+
+export async function fetchAvailability(listingId) {
+  const res = await api.get(`/listings/${listingId}/availability`);
+  return res.data; // expecting array of ISO date strings or ranges
+}

--- a/src/style.css
+++ b/src/style.css
@@ -70,6 +70,13 @@ body {
 
 .popover { position:fixed; z-index:1000; background:#fff; border:1px solid #e5e7eb; border-radius:10px; padding:8px; box-shadow:0 10px 20px rgba(0,0,0,.08); }
 
+.cal-backdrop { position:fixed; inset:0; background:rgba(0,0,0,.35); display:flex; align-items:flex-end; justify-content:center; z-index:1000; }
+.cal-sheet { width:100%; background:#fff; border-radius:12px 12px 0 0; padding:16px; box-shadow:0 -2px 10px rgba(0,0,0,.2); }
+.dp-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; }
+.dp-guide { font-size:.9rem; }
+.dp-clear { border:none; background:none; color:var(--color-primary); font-size:.85rem; text-decoration:underline; cursor:pointer; }
+.dp-clear:disabled { opacity:.5; text-decoration:none; cursor:default; }
+
 /* Banner at top */
 .notice { padding:8px 12px; background:#F9FAFB; border:1px solid #EEE; border-radius:8px; margin:8px 0; font-size:14px; }
 


### PR DESCRIPTION
## Summary
- add availability fetching and mobile bottom-sheet calendar for ListingCard and StickyDateBar
- block unavailable dates and guide users with check-in/check-out hints and a clear option
- expose availability API helper

## Testing
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a054278c1c832b9f054c4177f6052c