### PR TITLE
Add multi-step booking summary with progress bar and cost breakdown

### DIFF
--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { differenceInCalendarDays, format } from 'date-fns';
+import { useState } from 'react';
 import { getListingById } from '../data/listings';
 
 export default function BookingSummary() {
@@ -12,22 +13,32 @@ export default function BookingSummary() {
   }
 
   const listing = getListingById(state.listingId);
-  const checkIn = new Date(state.checkIn);
-  const checkOut = new Date(state.checkOut);
-  const nights = Math.max(1, differenceInCalendarDays(checkOut, checkIn));
-  const total = nights * listing.pricePerNight;
+  const [form, setForm] = useState({
+    checkIn: state.checkIn,
+    checkOut: state.checkOut,
+    guests: state.guests,
+    name: '',
+    phone: '',
+    email: ''
+  });
+  const [step, setStep] = useState(1);
 
-  const onProceed = (e) => {
-    e.preventDefault();
-    const fd = new FormData(e.currentTarget);
+  const checkIn = new Date(form.checkIn);
+  const checkOut = new Date(form.checkOut);
+  const nights = Math.max(1, differenceInCalendarDays(checkOut, checkIn));
+  const rate = listing.pricePerNight * nights;
+  const fees = Math.round(rate * 0.1);
+  const taxes = Math.round(rate * 0.12);
+  const total = rate + fees + taxes;
+
+  const handleChange = (e) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const onPay = () => {
     const payload = {
       listingId: listing.id,
-      checkIn: state.checkIn,
-      checkOut: state.checkOut,
-      guests: state.guests,
-      name: fd.get('name'),
-      phone: fd.get('phone'),
-      email: fd.get('email'),
+      ...form,
       amount: total
     };
     console.log('Proceed to Pay (Razorpay in Phase 2)', payload);
@@ -41,18 +52,111 @@ export default function BookingSummary() {
         <div>
           <h3>{listing.title}</h3>
           <div>{listing.location}</div>
-          <div>Dates: {format(checkIn,'dd MMM yyyy')} → {format(checkOut,'dd MMM yyyy')} ({nights} night{nights>1?'s':''})</div>
-          <div>Guests: {state.guests}</div>
-          <div>Price: ₹{listing.pricePerNight} × {nights} = <strong>₹{total}</strong></div>
+          <div>
+            Dates: {format(checkIn, 'dd MMM yyyy')} → {format(checkOut, 'dd MMM yyyy')} ({nights} night{nights > 1 ? 's' : ''})
+          </div>
+          <div>Guests: {form.guests}</div>
+          <div>Price: ₹{listing.pricePerNight} × {nights} = <strong>₹{rate}</strong></div>
         </div>
       </div>
 
-      <form onSubmit={onProceed} className="guest-form">
-        <label>Name<input name="name" required /></label>
-        <label>Phone<input name="phone" required /></label>
-        <label>Email<input name="email" type="email" required /></label>
-        <button className="primary" type="submit">Proceed to Pay</button>
-      </form>
+      <div className="progress-bar">
+        <div className="bar" style={{ width: `${((step - 1) / 2) * 100}%` }} />
+      </div>
+      <div className="progress-steps">
+        <span className={step === 1 ? 'active' : ''}>Select Dates</span>
+        <span className={step === 2 ? 'active' : ''}>Details</span>
+        <span className={step === 3 ? 'active' : ''}>Pay</span>
+      </div>
+
+      {step === 1 && (
+        <form
+          className="guest-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setStep(2);
+          }}
+        >
+          <label>
+            Check‑in
+            <input type="date" name="checkIn" value={form.checkIn} onChange={handleChange} required />
+          </label>
+          <label>
+            Check‑out
+            <input type="date" name="checkOut" value={form.checkOut} onChange={handleChange} required />
+          </label>
+          <div className="step-nav">
+            <button className="primary" type="submit">
+              Next
+            </button>
+          </div>
+        </form>
+      )}
+
+      {step === 2 && (
+        <form
+          className="guest-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setStep(3);
+          }}
+        >
+          <label>
+            Name
+            <input name="name" value={form.name} onChange={handleChange} required />
+          </label>
+          <label>
+            Phone
+            <input name="phone" value={form.phone} onChange={handleChange} required />
+          </label>
+          <label>
+            Email
+            <input name="email" type="email" value={form.email} onChange={handleChange} required />
+          </label>
+          <div className="step-nav">
+            <button type="button" onClick={() => setStep(1)}>
+              Back
+            </button>
+            <button className="primary" type="submit">
+              Next
+            </button>
+          </div>
+        </form>
+      )}
+
+      {step === 3 && (
+        <div>
+          <div className="cost-breakdown">
+            <div>
+              <span>₹{listing.pricePerNight} × {nights} nights</span>
+              <span>₹{rate}</span>
+            </div>
+            <div>
+              <span>Fees</span>
+              <span>₹{fees}</span>
+            </div>
+            <div>
+              <span>Taxes</span>
+              <span>₹{taxes}</span>
+            </div>
+            <div className="total">
+              <span>Total</span>
+              <span>₹{total}</span>
+            </div>
+          </div>
+          <div className="badges">
+            <span className="badge">Secure payment via Razorpay</span>
+          </div>
+          <div className="step-nav">
+            <button type="button" onClick={() => setStep(2)}>
+              Back
+            </button>
+            <button className="primary" type="button" onClick={onPay}>
+              Pay Now
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -148,3 +148,12 @@ body {
 .ftr__links { display:flex; gap:16px; }
 .ftr__links .icon-btn { border:none; background:transparent; color:#9ca3af; }
 .ftr__links .icon-btn:hover { color:#fff; }
+.progress-bar {height:8px; background:#e5e7eb; border-radius:4px; overflow:hidden; margin:16px 0 8px;}
+.progress-bar .bar {height:100%; background:var(--color-primary); width:0; transition:width .3s;}
+.progress-steps {display:flex; justify-content:space-between; font-size:.85rem; margin-bottom:16px;}
+.progress-steps .active {color:var(--color-primary); font-weight:600;}
+.cost-breakdown div {display:flex; justify-content:space-between; margin-bottom:4px;}
+.cost-breakdown .total {font-weight:600; border-top:1px solid #e5e7eb; padding-top:4px;}
+.badges {margin-top:8px;}
+.badge {display:inline-block; background:#f3f4f6; color:#374151; padding:4px 8px; border-radius:4px; font-size:.75rem;}
+.step-nav {display:flex; gap:8px; margin-top:16px;}


### PR DESCRIPTION
## Summary
- Introduce three-step booking flow (Select Dates → Details → Pay) with progress bar
- Persist user input across steps and show cost breakdown with fees and taxes
- Add Razorpay secure payment badge and supporting styles

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run build` *(fails: sh: 1: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a0542907b4832b8d54b149f51f6bee