### PR TITLE
feat: add booking and enquiry validation

### DIFF
--- a/src/components/shared/EnquiryModal.jsx
+++ b/src/components/shared/EnquiryModal.jsx
@@ -2,11 +2,15 @@ import { useState, useEffect, useRef } from 'react';
 import { format } from 'date-fns';
 import { CONTACT, ENQUIRY_WEBHOOK } from '../../config/siteConfig';
 
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const phoneRegex = /^\+?[1-9]\d{9,14}$/;
+
 export default function EnquiryModal({ onClose, listing, guests, preferredFrom, preferredTo }) {
   const [form, setForm] = useState({
     name: '', phone: '', email: '',
     message: ''
   });
+  const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
   const [ok, setOk] = useState(false);
   const firstInput = useRef(null);
@@ -19,8 +23,31 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
   const prefDates = preferredFrom && preferredTo
     ? `${format(preferredFrom,'dd MMM yyyy')} → ${format(preferredTo,'dd MMM yyyy')}` : '';
 
+  const validateField = (name, value) => {
+    if (name === 'email' && !emailRegex.test(value)) return 'Enter a valid email address';
+    if (name === 'phone' && !phoneRegex.test(value)) return 'Enter a valid phone number';
+    return '';
+  };
+
+  const handleChange = (name) => (e) => {
+    const value = e.target.value;
+    setForm(f => ({ ...f, [name]: value }));
+    setErrors(err => ({ ...err, [name]: validateField(name, value) }));
+  };
+
+  const validate = () => {
+    const errs = {};
+    ['phone','email'].forEach(key => {
+      const err = validateField(key, form[key]);
+      if (err) errs[key] = err;
+    });
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
   const submit = async (e) => {
     e.preventDefault();
+    if (!validate()) return;
     setSubmitting(true);
     const payload = {
       listingId: listing.id,
@@ -38,7 +65,8 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
           body: JSON.stringify(payload)
         });
         if (!res.ok) throw new Error('webhook failed');
-        setOk(true);
+        const data = await res.json().catch(() => ({}));
+        setOk(data.reference || true);
       } else {
         const subject = encodeURIComponent(`Enquiry: ${listing.title}`);
         const body = encodeURIComponent(
@@ -61,22 +89,32 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
-        <h3>Enquire about {listing.title}</h3>
-        {prefDates && <div className="muted">Preferred dates: {prefDates}</div>}
-        <form onSubmit={submit} className="modal-form">
-          <label>Full name<input ref={firstInput} required value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))} /></label>
-          <label>Phone<input required value={form.phone} onChange={e=>setForm(f=>({...f, phone:e.target.value}))} /></label>
-          <label>Email<input type="email" required value={form.email} onChange={e=>setForm(f=>({...f, email:e.target.value}))} /></label>
-          <label>Message (optional)<textarea rows="3" value={form.message} onChange={e=>setForm(f=>({...f, message:e.target.value}))} /></label>
-
-          <div className="notice-text">We’ll confirm availability and price over WhatsApp/phone. Online booking is coming soon.</div>
-
-          <div className="modal-actions">
-            <button type="button" className="btn-ghost" onClick={onClose}>Cancel</button>
-            <button className="btn-primary" disabled={submitting}>{submitting ? 'Sending…' : 'Send Enquiry'}</button>
+        {ok ? (
+          <div className="success">
+            <h3>Thanks! We’ll contact you shortly.</h3>
+            {typeof ok === 'string' && <div>Reference: {ok}</div>}
           </div>
-          {ok && <div className="success">Thanks! We’ll contact you shortly.</div>}
-        </form>
+        ) : (
+          <>
+            <h3>Enquire about {listing.title}</h3>
+            {prefDates && <div className="muted">Preferred dates: {prefDates}</div>}
+            <form onSubmit={submit} className="modal-form">
+              <label>Full name<input ref={firstInput} required value={form.name} onChange={handleChange('name')} /></label>
+              <label>Phone<input required value={form.phone} onChange={handleChange('phone')} /></label>
+              {errors.phone && <div className="error">{errors.phone}</div>}
+              <label>Email<input type="email" required value={form.email} onChange={handleChange('email')} /></label>
+              {errors.email && <div className="error">{errors.email}</div>}
+              <label>Message (optional)<textarea rows="3" value={form.message} onChange={handleChange('message')} /></label>
+
+              <div className="notice-text">We’ll confirm availability and price over WhatsApp/phone. Online booking is coming soon.</div>
+
+              <div className="modal-actions">
+                <button type="button" className="btn-ghost" onClick={onClose}>Cancel</button>
+                <button className="btn-primary" disabled={submitting}>{submitting ? 'Sending…' : 'Send Enquiry'}</button>
+              </div>
+            </form>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/EnquiryModal.jsx
+++ b/src/components/shared/EnquiryModal.jsx
@@ -100,7 +100,7 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
             {prefDates && <div className="muted">Preferred dates: {prefDates}</div>}
             <form onSubmit={submit} className="modal-form">
               <label>Full name<input ref={firstInput} required value={form.name} onChange={handleChange('name')} /></label>
-              <label>Phone<input required value={form.phone} onChange={handleChange('phone')} /></label>
+              <label>Phone<input type="tel" required value={form.phone} onChange={handleChange('phone')} /></label>
               {errors.phone && <div className="error">{errors.phone}</div>}
               <label>Email<input type="email" required value={form.email} onChange={handleChange('email')} /></label>
               {errors.email && <div className="error">{errors.email}</div>}

--- a/src/config/siteConfig.js
+++ b/src/config/siteConfig.js
@@ -7,3 +7,5 @@ export const CONTACT = {
 };
 
 export const ENQUIRY_WEBHOOK = import.meta.env.VITE_ENQUIRY_WEBHOOK_URL || '';
+export const BOOKING_WEBHOOK = import.meta.env.VITE_BOOKING_WEBHOOK_URL || "";
+

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -105,7 +105,7 @@ export default function BookingSummary() {
       <form onSubmit={onProceed} className="guest-form">
         <label>Name<input name="name" value={form.name} onChange={handleChange('name')} required /></label>
         {errors.name && <div className="error">{errors.name}</div>}
-        <label>Phone<input name="phone" value={form.phone} onChange={handleChange('phone')} required /></label>
+        <label>Phone<input name="phone" type="tel" value={form.phone} onChange={handleChange('phone')} required /></label>
         {errors.phone && <div className="error">{errors.phone}</div>}
         <label>Email<input name="email" type="email" value={form.email} onChange={handleChange('email')} required /></label>
         {errors.email && <div className="error">{errors.email}</div>}

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -1,6 +1,11 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { differenceInCalendarDays, format } from 'date-fns';
+import { useState } from 'react';
 import { getListingById } from '../data/listings';
+import { BOOKING_WEBHOOK } from '../config/siteConfig';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const phoneRegex = /^\+?[1-9]\d{9,14}$/;
 
 export default function BookingSummary() {
   const { state } = useLocation();
@@ -17,21 +22,71 @@ export default function BookingSummary() {
   const nights = Math.max(1, differenceInCalendarDays(checkOut, checkIn));
   const total = nights * listing.pricePerNight;
 
-  const onProceed = (e) => {
+  const [form, setForm] = useState({ name: '', phone: '', email: '' });
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [reference, setReference] = useState('');
+
+  const handleChange = (name) => (e) => {
+    const value = e.target.value;
+    setForm(f => ({ ...f, [name]: value }));
+    setErrors(err => ({ ...err, [name]: '' }));
+  };
+
+  const validate = () => {
+    const errs = {};
+    if (!phoneRegex.test(form.phone)) errs.phone = 'Enter a valid phone number';
+    if (!emailRegex.test(form.email)) errs.email = 'Enter a valid email address';
+    if (!form.name) errs.name = 'Name is required';
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const onProceed = async (e) => {
     e.preventDefault();
-    const fd = new FormData(e.currentTarget);
+    if (!validate()) return;
+    setSubmitting(true);
     const payload = {
       listingId: listing.id,
       checkIn: state.checkIn,
       checkOut: state.checkOut,
       guests: state.guests,
-      name: fd.get('name'),
-      phone: fd.get('phone'),
-      email: fd.get('email'),
+      name: form.name,
+      phone: form.phone,
+      email: form.email,
       amount: total
     };
-    console.log('Proceed to Pay (Razorpay in Phase 2)', payload);
+    try {
+      if (BOOKING_WEBHOOK) {
+        const res = await fetch(BOOKING_WEBHOOK, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error('webhook failed');
+        const data = await res.json().catch(() => ({}));
+        setReference(data.reference || data.bookingRef || '');
+      } else {
+        alert('Booking submitted. Configure BOOKING_WEBHOOK to enable confirmations.');
+        setReference('TEMP');
+      }
+    } catch {
+      alert('Could not complete booking. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
   };
+
+  if (reference) {
+    return (
+      <div className="summary">
+        <h2>Booking Confirmed</h2>
+        <p>Your booking reference is <strong>{reference}</strong>.</p>
+        <p>We have sent a confirmation message. Our team will reach out with next steps.</p>
+        <button className="primary" onClick={() => nav('/')}>Back to Home</button>
+      </div>
+    );
+  }
 
   return (
     <div className="summary">
@@ -48,10 +103,13 @@ export default function BookingSummary() {
       </div>
 
       <form onSubmit={onProceed} className="guest-form">
-        <label>Name<input name="name" required /></label>
-        <label>Phone<input name="phone" required /></label>
-        <label>Email<input name="email" type="email" required /></label>
-        <button className="primary" type="submit">Proceed to Pay</button>
+        <label>Name<input name="name" value={form.name} onChange={handleChange('name')} required /></label>
+        {errors.name && <div className="error">{errors.name}</div>}
+        <label>Phone<input name="phone" value={form.phone} onChange={handleChange('phone')} required /></label>
+        {errors.phone && <div className="error">{errors.phone}</div>}
+        <label>Email<input name="email" type="email" value={form.email} onChange={handleChange('email')} required /></label>
+        {errors.email && <div className="error">{errors.email}</div>}
+        <button className="primary" type="submit" disabled={submitting}>{submitting ? 'Submitting…' : 'Proceed to Pay'}</button>
       </form>
     </div>
   );

--- a/src/style.css
+++ b/src/style.css
@@ -127,6 +127,7 @@ body {
 .modal-form input, .modal-form textarea { border:1px solid #e5e7eb; border-radius:8px; padding:8px; }
 .modal-actions { display:flex; gap:8px; justify-content:flex-end; margin-top:8px; }
 .success { margin-top:8px; color:#065f46; background:#ecfdf5; padding:8px; border-radius:8px; font-size:.9rem; }
+.error { margin-top:4px; color:#b91c1c; font-size:.8rem; }
 @media (max-width: 768px) {
   .contact-strip { position:fixed; bottom:0; left:0; right:0; display:flex; align-items:center; gap:12px; background:#fff; padding:10px 16px; box-shadow:0 -2px 5px rgba(0,0,0,.1); z-index:40; }
   .contact-strip .price { font-weight:600; }


### PR DESCRIPTION
## Summary
- validate phone and email in enquiry and booking forms with inline errors
- show booking confirmation with reference and transactional webhook
- style and config updates for webhook endpoint and errors

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a05433f678832ba3a6ec9e6c0fe5f2