### PR TITLE
Show social icons only in footer

### DIFF
--- a/src/components/chrome/Footer.jsx
+++ b/src/components/chrome/Footer.jsx
@@ -1,33 +1,34 @@
 import { SOCIAL } from '../../config/social';
 
 export default function Footer() {
+  const socialLinks = [
+    { href: SOCIAL.instagram, icon: 'fa-instagram', label: 'Instagram' },
+    { href: SOCIAL.facebook, icon: 'fa-facebook', label: 'Facebook' },
+  ].filter(({ href }) => href);
+
   return (
     <footer className="ftr">
       <div className="ftr__wrap">
         <div>© {new Date().getFullYear()} Atlas Homestays • Hyderabad</div>
-        <div className="ftr__social">
-          <span className="ftr__follow">Follow us</span>
-          <div className="ftr__links">
-            <a
-              href={SOCIAL.instagram}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Instagram"
-              className="icon-btn"
-            >
-              <i className="fa-brands fa-instagram"></i>
-            </a>
-            <a
-              href={SOCIAL.facebook}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Facebook"
-              className="icon-btn"
-            >
-              <i className="fa-brands fa-facebook"></i>
-            </a>
+        {socialLinks.length > 0 && (
+          <div className="ftr__social">
+            <span className="ftr__follow">Follow us</span>
+            <div className="ftr__links">
+              {socialLinks.map(({ href, icon, label }) => (
+                <a
+                  key={label}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={label}
+                  className="icon-btn"
+                >
+                  <i className={`fa-brands ${icon}`}></i>
+                </a>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </footer>
   );

--- a/src/components/chrome/Footer.jsx
+++ b/src/components/chrome/Footer.jsx
@@ -5,22 +5,28 @@ export default function Footer() {
     <footer className="ftr">
       <div className="ftr__wrap">
         <div>© {new Date().getFullYear()} Atlas Homestays • Hyderabad</div>
-        <div className="ftr__links">
-          <a href={SOCIAL.instagram} target="_blank" rel="noreferrer" aria-label="Instagram" className="icon-btn">
-            <i className="fa-brands fa-instagram"></i>
-          </a>
-          <a href={SOCIAL.facebook} target="_blank" rel="noreferrer" aria-label="Facebook" className="icon-btn">
-            <i className="fa-brands fa-facebook"></i>
-          </a>
-          <a href={SOCIAL.whatsapp} aria-label="WhatsApp" className="icon-btn whatsapp">
-            <i className="fa-brands fa-whatsapp"></i>
-          </a>
-          <a href={SOCIAL.phone} aria-label="Call" className="icon-btn">
-            <i className="fa-solid fa-phone"></i>
-          </a>
-          <a href={SOCIAL.email} aria-label="Email" className="icon-btn">
-            <i className="fa-solid fa-envelope"></i>
-          </a>
+        <div className="ftr__social">
+          <span className="ftr__follow">Follow us</span>
+          <div className="ftr__links">
+            <a
+              href={SOCIAL.instagram}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+              className="icon-btn"
+            >
+              <i className="fa-brands fa-instagram"></i>
+            </a>
+            <a
+              href={SOCIAL.facebook}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook"
+              className="icon-btn"
+            >
+              <i className="fa-brands fa-facebook"></i>
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/chrome/Header.jsx
+++ b/src/components/chrome/Header.jsx
@@ -11,12 +11,6 @@ export default function Header() {
           <a href="#contact">Contact</a>
         </nav>
         <div className="hdr__actions">
-          <a href={SOCIAL.instagram} target="_blank" rel="noreferrer" aria-label="Instagram" className="icon-btn">
-            <i className="fa-brands fa-instagram"></i>
-          </a>
-          <a href={SOCIAL.facebook} target="_blank" rel="noreferrer" aria-label="Facebook" className="icon-btn">
-            <i className="fa-brands fa-facebook"></i>
-          </a>
           <a href={SOCIAL.whatsapp} aria-label="WhatsApp" className="icon-btn whatsapp">
             <i className="fa-brands fa-whatsapp"></i>
           </a>

--- a/src/style.css
+++ b/src/style.css
@@ -145,6 +145,8 @@ body {
 
 .ftr { background:#111827; color:#fff; margin-top:32px; }
 .ftr__wrap { max-width:1120px; margin:0 auto; padding:16px; display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; }
+.ftr__social { display:flex; flex-direction:column; align-items:flex-end; }
+.ftr__follow { font-size:12px; color:#6b7280; margin-bottom:4px; }
 .ftr__links { display:flex; gap:16px; }
-.ftr__links .icon-btn { border:none; background:transparent; color:#9ca3af; }
-.ftr__links .icon-btn:hover { color:#fff; }
+.ftr__links .icon-btn { border:none; background:transparent; color:#6b7280; }
+.ftr__links .icon-btn:hover { color:#374151; }


### PR DESCRIPTION
## Summary
- Move Instagram and Facebook icons out of the header and keep them exclusively in the footer
- Introduce a "Follow us" label with muted social icons that open in new tabs
- Add footer styles for new social section and muted icon palette

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a0544b9f48832ba230b77c3a29186e