### PR TITLE
Use DayPicker with locale and ARIA in GuestBooking

### DIFF
--- a/src/pages/GuestBooking.jsx
+++ b/src/pages/GuestBooking.jsx
@@ -1,31 +1,32 @@
 // src/pages/GuestBooking.jsx
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { DayPicker } from 'react-day-picker';
+import { format, parseISO } from 'date-fns';
+import { enUS } from 'date-fns/locale';
+import 'react-day-picker/dist/style.css';
 
 const GuestBooking = () => {
     const [listings, setListings] = useState([]);
-    const [selected, setSelected] = useState([]);
+    const [selected, setSelected] = useState([]); // { listingId, date }
     const [guest, setGuest] = useState({ name: '', phone: '', email: '' });
-    const [calendarDays, setCalendarDays] = useState([]);
+    const [locale, setLocale] = useState(enUS);
 
     useEffect(() => {
-        axios.get(`${import.meta.env.VITE_API_BASE}/listings`).then(res => setListings(res.data));
-        const today = new Date();
-        const days = Array.from({ length: 14 }, (_, i) => {
-            const date = new Date(today);
-            date.setDate(today.getDate() + i);
-            return date.toISOString().split('T')[0];
-        });
-        setCalendarDays(days);
+        axios
+            .get(`${import.meta.env.VITE_API_BASE}/listings`)
+            .then(res => setListings(res.data));
+
+        const userLocale = navigator.language;
+        import(`date-fns/locale/${userLocale}/index.js`)
+            .then(mod => setLocale(mod.default))
+            .catch(() => setLocale(enUS));
     }, []);
 
-    const toggle = (listingId, date) => {
-        const exists = selected.find(x => x.listingId === listingId && x.date === date);
-        if (exists) {
-            setSelected(selected.filter(x => !(x.listingId === listingId && x.date === date)));
-        } else {
-            setSelected([...selected, { listingId, date }]);
-        }
+    const handleSelect = (listingId, dates) => {
+        const others = selected.filter(x => x.listingId !== listingId);
+        const newDates = (dates || []).map(d => ({ listingId, date: format(d, 'yyyy-MM-dd') }));
+        setSelected([...others, ...newDates]);
     };
 
     const groupByListing = () => {
@@ -58,29 +59,20 @@ const GuestBooking = () => {
     return (
         <div>
             <h2>📅 Multi-Listing Booking</h2>
-            <div className="calendar-grid">
-                <table>
-                    <thead>
-                        <tr><th>Listing</th>{calendarDays.map(d => <th key={d}>{d.slice(5)}</th>)}</tr>
-                    </thead>
-                    <tbody>
-                        {listings.map(l => (
-                            <tr key={l.id}>
-                                <td>{l.name}</td>
-                                {calendarDays.map(d => (
-                                    <td
-                                        key={d}
-                                        className={selected.find(x => x.listingId === l.id && x.date === d) ? 'selected' : 'cell'}
-                                        onClick={() => toggle(l.id, d)}
-                                    >
-                                        {selected.find(x => x.listingId === l.id && x.date === d) ? '✔' : ''}
-                                    </td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+            {listings.map(l => (
+                <div key={l.id} className="listing-picker">
+                    <h3 id={`listing-${l.id}`}>{l.name}</h3>
+                    <DayPicker
+                        mode="multiple"
+                        selected={selected
+                            .filter(x => x.listingId === l.id)
+                            .map(x => parseISO(x.date))}
+                        onSelect={dates => handleSelect(l.id, dates)}
+                        locale={locale}
+                        aria-labelledby={`listing-${l.id}`}
+                    />
+                </div>
+            ))}
             <div className="summary">
                 <h3>Guest Details</h3>
                 <input placeholder='Name' value={guest.name} onChange={e => setGuest({ ...guest, name: e.target.value })} />


### PR DESCRIPTION
## Summary
- Replace custom table-based booking grid with `DayPicker` per listing
- Load appropriate `date-fns` locale from browser settings and apply to calendar
- Improve accessibility using ARIA labels on each calendar

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a054e24678832b91e1754792c906c0