### PR TITLE
Refactor listings to structured addresses and map links

### DIFF
--- a/src/components/listings/ListingCard.jsx
+++ b/src/components/listings/ListingCard.jsx
@@ -6,6 +6,7 @@ import { DayPicker } from 'react-day-picker';
 import { format } from 'date-fns';
 import EnquiryModal from '../shared/EnquiryModal';
 import { CONTACT } from '../../config/siteConfig';
+import { formatAddress, getMapLink } from '../../utils/address';
 
 export default function ListingCard({ listing, prefillDates, prefillGuests }) {
   const [openCal, setOpenCal] = useState(false);
@@ -54,8 +55,10 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
     return `https://wa.me/${CONTACT.whatsappE164.replace('+','')}?text=${msg}`;
   })();
 
-
+  
   const hasPref = range.from && range.to;
+  const formattedAddress = formatAddress(listing.address);
+  const mapLink = getMapLink(listing.address);
 
   return (
     <div className="lc-card">
@@ -65,7 +68,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
       <div className="lc-body">
         <div className="lc-header">
           <h3 className="lc-title"><Link to={`/listings/${listing.id}`}>{listing.title}</Link></h3>
-          <div className="lc-sub">{listing.location}</div>
+          <div className="lc-sub"><a href={mapLink} target="_blank" rel="noreferrer">{formattedAddress}</a></div>
           <div className="lc-price">₹{listing.pricePerNight} / night</div>
         </div>
 

--- a/src/data/listings.js
+++ b/src/data/listings.js
@@ -1,11 +1,95 @@
 export const listings = [
-  { id: 501, title: 'Penthouse 501', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/501/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 4500 },
-  { id: 301, title: 'Room 301', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/301/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 3000 },
-  { id: 302, title: 'Room 302', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/302/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 3200 },
-  { id: 201, title: 'Room 201', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/201/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 2500 },
-  { id: 202, title: 'Room 202', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/202/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 2600 },
-  { id: 101, title: 'Room 101', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/101/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 2400 },
-  { id: 102, title: 'Room 102', imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/102/cover.jpg', location: 'KPHB, Hyderabad', pricePerNight: 2300 }
+  {
+    id: 501,
+    title: 'Penthouse 501',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/501/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 4500
+  },
+  {
+    id: 301,
+    title: 'Room 301',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/301/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 3000
+  },
+  {
+    id: 302,
+    title: 'Room 302',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/302/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 3200
+  },
+  {
+    id: 201,
+    title: 'Room 201',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/201/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 2500
+  },
+  {
+    id: 202,
+    title: 'Room 202',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/202/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 2600
+  },
+  {
+    id: 101,
+    title: 'Room 101',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/101/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 2400
+  },
+  {
+    id: 102,
+    title: 'Room 102',
+    imageUrl: 'https://atlashomestorage.blob.core.windows.net/listing-images/102/cover.jpg',
+    address: {
+      street: 'KPHB Colony',
+      city: 'Hyderabad',
+      state: 'Telangana',
+      postalCode: '500072',
+      country: 'IN'
+    },
+    pricePerNight: 2300
+  }
 ];
 
 export const getListingById = (id) => listings.find(l => l.id === Number(id));

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { getListingById } from '../data/listings';
+import { formatAddress } from '../utils/address';
 
 export default function BookingSummary() {
   const { state } = useLocation();
@@ -40,7 +41,7 @@ export default function BookingSummary() {
         <img src={listing.imageUrl} alt={listing.title} />
         <div>
           <h3>{listing.title}</h3>
-          <div>{listing.location}</div>
+          <div>{formatAddress(listing.address)}</div>
           <div>Dates: {format(checkIn,'dd MMM yyyy')} → {format(checkOut,'dd MMM yyyy')} ({nights} night{nights>1?'s':''})</div>
           <div>Guests: {state.guests}</div>
           <div>Price: ₹{listing.pricePerNight} × {nights} = <strong>₹{total}</strong></div>

--- a/src/pages/ListingDetails.jsx
+++ b/src/pages/ListingDetails.jsx
@@ -4,6 +4,7 @@ import { getListingById } from '../data/listings';
 import { CONTACT } from '../config/siteConfig';
 import EnquiryModal from '../components/shared/EnquiryModal';
 import ContactStrip from '../components/shared/ContactStrip';
+import { formatAddress, getMapLink } from '../utils/address';
 
 export default function ListingDetails() {
   const { id } = useParams();
@@ -19,6 +20,9 @@ export default function ListingDetails() {
     return `https://wa.me/${CONTACT.whatsappE164.replace('+','')}?text=${msg}`;
   })();
 
+  const formattedAddress = formatAddress(listing.address);
+  const mapLink = getMapLink(listing.address);
+
   return (
     <div className="card">
       <div className="lc-media">
@@ -26,7 +30,7 @@ export default function ListingDetails() {
       </div>
       <div className="lc-body d-flex flex-column">
         <h3 className="lc-title">{listing.title}</h3>
-        <div className="lc-sub">{listing.location}</div>
+        <div className="lc-sub"><a href={mapLink} target="_blank" rel="noreferrer">{formattedAddress}</a></div>
         <div className="lc-price">₹{listing.pricePerNight} / night</div>
       </div>
       {openEnquiry && (

--- a/src/utils/address.js
+++ b/src/utils/address.js
@@ -1,0 +1,23 @@
+export function formatCountry(code, locale = 'en') {
+  try {
+    const formatter = new Intl.DisplayNames([locale], { type: 'region' });
+    return formatter.of(code);
+  } catch (e) {
+    return code;
+  }
+}
+
+export function formatAddress(address, locale = 'en') {
+  if (!address) return '';
+  const { street, city, state, postalCode, country } = address;
+  const countryName = country ? formatCountry(country, locale) : '';
+  return [street, city, state, postalCode, countryName].filter(Boolean).join(', ');
+}
+
+export function getMapLink(address) {
+  if (!address) return '#';
+  const query = [address.street, address.city, address.state, address.postalCode, address.country]
+    .filter(Boolean)
+    .join(', ');
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+}


### PR DESCRIPTION
## Summary
- store listing addresses as structured objects instead of a single string
- show formatted address with Google Maps links on listing cards and details
- normalize country names using `Intl.DisplayNames` utility

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a054e314c8832bbba1b15b585af48b