### PR TITLE
Add accessible labels and hints for contact forms

### DIFF
--- a/src/components/shared/EnquiryModal.jsx
+++ b/src/components/shared/EnquiryModal.jsx
@@ -64,10 +64,51 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
         <h3>Enquire about {listing.title}</h3>
         {prefDates && <div className="muted">Preferred dates: {prefDates}</div>}
         <form onSubmit={submit} className="modal-form">
-          <label>Full name<input ref={firstInput} required value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))} /></label>
-          <label>Phone<input required value={form.phone} onChange={e=>setForm(f=>({...f, phone:e.target.value}))} /></label>
-          <label>Email<input type="email" required value={form.email} onChange={e=>setForm(f=>({...f, email:e.target.value}))} /></label>
-          <label>Message (optional)<textarea rows="3" value={form.message} onChange={e=>setForm(f=>({...f, message:e.target.value}))} /></label>
+          <label>
+            Full name
+            <input
+              name="name"
+              type="text"
+              autoComplete="name"
+              ref={firstInput}
+              required
+              value={form.name}
+              onChange={e=>setForm(f=>({...f, name:e.target.value}))}
+            />
+          </label>
+          <label>
+            Phone
+            <input
+              name="phone"
+              type="tel"
+              autoComplete="tel"
+              aria-describedby="enq-phone-hint"
+              required
+              value={form.phone}
+              onChange={e=>setForm(f=>({...f, phone:e.target.value}))}
+            />
+            <span id="enq-phone-hint" className="hint">Include country code, e.g., +1 555-555-5555</span>
+          </label>
+          <label>
+            Email
+            <input
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={form.email}
+              onChange={e=>setForm(f=>({...f, email:e.target.value}))}
+            />
+          </label>
+          <label>
+            Message (optional)
+            <textarea
+              name="message"
+              rows="3"
+              value={form.message}
+              onChange={e=>setForm(f=>({...f, message:e.target.value}))}
+            />
+          </label>
 
           <div className="notice-text">We’ll confirm availability and price over WhatsApp/phone. Online booking is coming soon.</div>
 

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -48,9 +48,25 @@ export default function BookingSummary() {
       </div>
 
       <form onSubmit={onProceed} className="guest-form">
-        <label>Name<input name="name" required /></label>
-        <label>Phone<input name="phone" required /></label>
-        <label>Email<input name="email" type="email" required /></label>
+        <label>
+          Name
+          <input name="name" type="text" autoComplete="name" required />
+        </label>
+        <label>
+          Phone
+          <input
+            name="phone"
+            type="tel"
+            autoComplete="tel"
+            aria-describedby="bs-phone-hint"
+            required
+          />
+          <span id="bs-phone-hint" className="hint">Include country code, e.g., +1 555-555-5555</span>
+        </label>
+        <label>
+          Email
+          <input name="email" type="email" autoComplete="email" required />
+        </label>
         <button className="primary" type="submit">Proceed to Pay</button>
       </form>
     </div>

--- a/src/pages/GuestBooking.jsx
+++ b/src/pages/GuestBooking.jsx
@@ -83,9 +83,38 @@ const GuestBooking = () => {
             </div>
             <div className="summary">
                 <h3>Guest Details</h3>
-                <input placeholder='Name' value={guest.name} onChange={e => setGuest({ ...guest, name: e.target.value })} />
-                <input placeholder='Phone' value={guest.phone} onChange={e => setGuest({ ...guest, phone: e.target.value })} />
-                <input placeholder='Email' value={guest.email} onChange={e => setGuest({ ...guest, email: e.target.value })} />
+                <label>
+                    Name
+                    <input
+                        name="name"
+                        type="text"
+                        autoComplete="name"
+                        value={guest.name}
+                        onChange={e => setGuest({ ...guest, name: e.target.value })}
+                    />
+                </label>
+                <label>
+                    Phone
+                    <input
+                        name="phone"
+                        type="tel"
+                        autoComplete="tel"
+                        aria-describedby="gb-phone-hint"
+                        value={guest.phone}
+                        onChange={e => setGuest({ ...guest, phone: e.target.value })}
+                    />
+                    <span id="gb-phone-hint" className="hint">Include country code, e.g., +1 555-555-5555</span>
+                </label>
+                <label>
+                    Email
+                    <input
+                        name="email"
+                        type="email"
+                        autoComplete="email"
+                        value={guest.email}
+                        onChange={e => setGuest({ ...guest, email: e.target.value })}
+                    />
+                </label>
                 <button onClick={submit}>Book Selected</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add explicit labels, name/type/autocomplete for guest booking form
- improve booking summary and enquiry modal with labelled inputs and phone hints
- provide guidance for international dialing formats

## Testing
- `npm test` *(fails: missing Xvfb)*
- `npx @axe-core/cli --version` *(fails: no output in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a054e46a78832ba82d202b10eaf856