### PR TITLE
Add internationalization and language switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
             "dependencies": {
                 "axios": "^1.0.0",
                 "date-fns": "^4.1.0",
+                "i18next": "^25.3.6",
                 "react": "^18.0.0",
                 "react-day-picker": "^9.8.1",
                 "react-dom": "^18.0.0",
+                "react-i18next": "^15.6.1",
                 "react-router-dom": "^6.0.0"
             },
             "devDependencies": {
@@ -257,6 +259,15 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+            "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -2484,6 +2495,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/html-parse-stringify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+            "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "3.1.0"
+            }
+        },
         "node_modules/http-signature": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -2507,6 +2527,37 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.12.0"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "25.3.6",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.6.tgz",
+            "integrity": "sha512-dThZ0CTCM3sUG/qS0ZtQYZQcUI6DtBN8yBHK+SKEqihPcEYmjVWh/YJ4luic73Iq6Uxhp6q7LJJntRK5+1t7jQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://locize.com"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://locize.com/i18next.html"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.27.6"
+            },
+            "peerDependencies": {
+                "typescript": "^5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ieee754": {
@@ -3196,6 +3247,32 @@
                 "react": "^18.3.1"
             }
         },
+        "node_modules/react-i18next": {
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+            "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.27.6",
+                "html-parse-stringify": "^3.0.1"
+            },
+            "peerDependencies": {
+                "i18next": ">= 23.2.3",
+                "react": ">= 16.8.0",
+                "typescript": "^5"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-refresh": {
             "version": "0.17.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3826,6 +3903,15 @@
                 "terser": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "dependencies": {
         "axios": "^1.0.0",
         "date-fns": "^4.1.0",
+        "i18next": "^25.3.6",
         "react": "^18.0.0",
         "react-day-picker": "^9.8.1",
         "react-dom": "^18.0.0",
+        "react-i18next": "^15.6.1",
         "react-router-dom": "^6.0.0"
     },
     "devDependencies": {

--- a/src/components/chrome/Header.jsx
+++ b/src/components/chrome/Header.jsx
@@ -1,14 +1,17 @@
 import { SOCIAL } from '../../config/social';
+import { useTranslation } from 'react-i18next';
 
 export default function Header() {
+  const { t, i18n } = useTranslation();
+
   return (
     <header className="hdr">
       <div className="hdr__wrap">
         <div className="brand">Atlas Homestays</div>
         <nav className="nav">
-          <a href="/">Home</a>
-          <a href="#about">About</a>
-          <a href="#contact">Contact</a>
+          <a href="/">{t('navigation.home')}</a>
+          <a href="#about">{t('navigation.about')}</a>
+          <a href="#contact">{t('navigation.contact')}</a>
         </nav>
         <div className="hdr__actions">
           <a href={SOCIAL.instagram} target="_blank" rel="noreferrer" aria-label="Instagram" className="icon-btn">
@@ -26,6 +29,14 @@ export default function Header() {
           <a href={SOCIAL.email} aria-label="Email" className="icon-btn">
             <i className="fa-solid fa-envelope"></i>
           </a>
+          <select
+            value={i18n.language}
+            onChange={e => i18n.changeLanguage(e.target.value)}
+            className="lang-select"
+          >
+            <option value="en">EN</option>
+            <option value="es">ES</option>
+          </select>
         </div>
       </div>
     </header>

--- a/src/components/listings/ListingCard.jsx
+++ b/src/components/listings/ListingCard.jsx
@@ -6,8 +6,12 @@ import { DayPicker } from 'react-day-picker';
 import { format } from 'date-fns';
 import EnquiryModal from '../shared/EnquiryModal';
 import { CONTACT } from '../../config/siteConfig';
+import { useTranslation } from 'react-i18next';
+import { dateLocales } from '../../i18n';
 
 export default function ListingCard({ listing, prefillDates, prefillGuests }) {
+  const { t, i18n } = useTranslation();
+  const locale = dateLocales[i18n.language];
   const [openCal, setOpenCal] = useState(false);
   const btnRef = useRef(null);
   const popRef = useRef(null);
@@ -41,7 +45,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
   }, [openCal]);
 
   const preferredLabel = range.from && range.to
-    ? `${format(range.from,'dd MMM')} → ${format(range.to,'dd MMM')}`
+    ? `${format(range.from,'P',{ locale })} → ${format(range.to,'P',{ locale })}`
     : '';
 
   const whatsappLink = (() => {
@@ -75,28 +79,28 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
               ref={btnRef}
               className="lc-chip"
               onClick={() => setOpenCal(v => !v)}
-              aria-label="Open preferred dates calendar"
+              aria-label={t('listingCard.openCalendar')}
               aria-expanded={openCal}
             >
-              📅 {hasPref ? preferredLabel : 'Preferred dates'}
+              📅 {hasPref ? preferredLabel : t('listingCard.preferredDates')}
             </button>
           </div>
 
           <select className="lc-select" value={guests} onChange={e => setGuests(Number(e.target.value))}>
             {[...Array(6)].map((_, i) => (
               <option key={i + 1} value={i + 1}>
-                {i + 1} Guest{i ? 's' : ''}
+                {t('common.guest', { count: i + 1 })}
               </option>
             ))}
           </select>
 
           <div className={`lc-pill ${hasPref ? 'ok' : 'muted'}`}>
-            {hasPref ? 'Dates noted (no instant booking)' : 'Add preferred dates'}
+            {hasPref ? t('listingCard.datesNoted') : t('listingCard.addPreferredDates')}
           </div>
 
           <div className="lc-actions">
             <button className="btn-dark" onClick={() => setOpenEnquiry(true)}>
-              Enquire Now
+              {t('listingCard.enquireNow')}
             </button>
             <a className="icon-btn whatsapp" href={whatsappLink} target="_blank" rel="noreferrer" aria-label="WhatsApp">
               <i className="fa-brands fa-whatsapp"></i>
@@ -118,7 +122,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
       {openCal && (
         <PopoverPortal>
           <div ref={popRef} className="popover" style={{ top: coords.top, left: coords.left, width: coords.width }}>
-            <DayPicker mode="range" selected={range} onSelect={setRange} />
+            <DayPicker mode="range" selected={range} onSelect={setRange} locale={locale} />
           </div>
         </PopoverPortal>
       )}

--- a/src/components/search/StickyDateBar.jsx
+++ b/src/components/search/StickyDateBar.jsx
@@ -4,8 +4,12 @@ import { useOnClickOutside, useOnEsc } from '../../hooks/useOnClickOutside';
 import { format } from 'date-fns';
 import { DayPicker } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';
+import { useTranslation } from 'react-i18next';
+import { dateLocales } from '../../i18n';
 
 export default function StickyDateBar({ onSearch, initialDates, initialGuests }) {
+  const { t, i18n } = useTranslation();
+  const locale = dateLocales[i18n.language];
   const [open, setOpen] = useState(false);
   const btnRef = useRef(null);
   const popRef = useRef(null);
@@ -32,8 +36,8 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
   }, [open]);
 
   const label = range.from && range.to
-    ? `${format(range.from,'dd MMM')} → ${format(range.to,'dd MMM')}`
-    : 'Preferred dates';
+    ? `${format(range.from,'P',{ locale })} → ${format(range.to,'P',{ locale })}`
+    : t('search.preferredDates');
 
   return (
     <div className="sb-wrap">
@@ -41,7 +45,7 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
         ref={btnRef}
         className="sb-chip"
         onClick={() => setOpen(v => !v)}
-        aria-label="Open preferred dates calendar"
+        aria-label={t('search.openCalendar')}
         aria-expanded={open}
       >
         {label}
@@ -49,15 +53,15 @@ export default function StickyDateBar({ onSearch, initialDates, initialGuests })
       {open && (
         <PopoverPortal>
           <div ref={popRef} className="popover" style={{ top: coords.top, left: coords.left, width: coords.width }}>
-            <DayPicker mode="range" selected={range} onSelect={setRange} />
+            <DayPicker mode="range" selected={range} onSelect={setRange} locale={locale} />
           </div>
         </PopoverPortal>
       )}
       <select className="sb-select" value={guests} onChange={e => setGuests(Number(e.target.value))}>
-        {[...Array(6)].map((_,i)=> <option key={i+1} value={i+1}>{i+1} Guest{i? 's':''}</option>)}
+        {[...Array(6)].map((_,i)=> <option key={i+1} value={i+1}>{t('common.guest', { count: i+1 })}</option>)}
       </select>
       <button className="btn-primary" onClick={() => onSearch({ dates: range, guests })} disabled={!range.from || !range.to}>
-        Search
+        {t('search.search')}
       </button>
     </div>
   );

--- a/src/components/shared/EnquiryModal.jsx
+++ b/src/components/shared/EnquiryModal.jsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 import { format } from 'date-fns';
 import { CONTACT, ENQUIRY_WEBHOOK } from '../../config/siteConfig';
+import { useTranslation } from 'react-i18next';
+import { dateLocales } from '../../i18n';
 
 export default function EnquiryModal({ onClose, listing, guests, preferredFrom, preferredTo }) {
+  const { i18n } = useTranslation();
+  const locale = dateLocales[i18n.language];
   const [form, setForm] = useState({
     name: '', phone: '', email: '',
     message: ''
@@ -17,7 +21,7 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
   const prefDates = preferredFrom && preferredTo
-    ? `${format(preferredFrom,'dd MMM yyyy')} → ${format(preferredTo,'dd MMM yyyy')}` : '';
+    ? `${format(preferredFrom,'P',{ locale })} → ${format(preferredTo,'P',{ locale })}` : '';
 
   const submit = async (e) => {
     e.preventDefault();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,33 @@
+{
+  "navigation": {
+    "home": "Home",
+    "about": "About",
+    "contact": "Contact"
+  },
+  "listingCard": {
+    "preferredDates": "Preferred dates",
+    "openCalendar": "Open preferred dates calendar",
+    "datesNoted": "Dates noted (no instant booking)",
+    "addPreferredDates": "Add preferred dates",
+    "enquireNow": "Enquire Now"
+  },
+  "search": {
+    "preferredDates": "Preferred dates",
+    "openCalendar": "Open preferred dates calendar",
+    "search": "Search"
+  },
+  "bookingSummary": {
+    "title": "Booking Summary",
+    "dates": "Dates",
+    "guests": "Guests",
+    "price": "Price",
+    "name": "Name",
+    "phone": "Phone",
+    "email": "Email",
+    "proceed": "Proceed to Pay"
+  },
+  "common": {
+    "guest": "{{count}} Guest",
+    "guest_plural": "{{count}} Guests"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,33 @@
+{
+  "navigation": {
+    "home": "Inicio",
+    "about": "Acerca de",
+    "contact": "Contacto"
+  },
+  "listingCard": {
+    "preferredDates": "Fechas preferidas",
+    "openCalendar": "Abrir calendario de fechas preferidas",
+    "datesNoted": "Fechas anotadas (sin reserva instantánea)",
+    "addPreferredDates": "Agregar fechas preferidas",
+    "enquireNow": "Consultar ahora"
+  },
+  "search": {
+    "preferredDates": "Fechas preferidas",
+    "openCalendar": "Abrir calendario de fechas preferidas",
+    "search": "Buscar"
+  },
+  "bookingSummary": {
+    "title": "Resumen de reserva",
+    "dates": "Fechas",
+    "guests": "Huéspedes",
+    "price": "Precio",
+    "name": "Nombre",
+    "phone": "Teléfono",
+    "email": "Correo electrónico",
+    "proceed": "Proceder al pago"
+  },
+  "common": {
+    "guest": "{{count}} huésped",
+    "guest_plural": "{{count}} huéspedes"
+  }
+}

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,22 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { enUS, es } from 'date-fns/locale';
+
+import en from './en.json';
+import esTranslations from './es.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      es: { translation: esTranslations }
+    },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false }
+  });
+
+export const dateLocales = { en: enUS, es };
+
+export default i18n;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import AppRoutes from './routes';
+import './i18n';
 import './style.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -1,10 +1,14 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { getListingById } from '../data/listings';
+import { useTranslation } from 'react-i18next';
+import { dateLocales } from '../i18n';
 
 export default function BookingSummary() {
   const { state } = useLocation();
   const nav = useNavigate();
+  const { t, i18n } = useTranslation();
+  const locale = dateLocales[i18n.language];
 
   if (!state?.listingId || !state?.checkIn || !state?.checkOut) {
     nav('/');
@@ -35,23 +39,23 @@ export default function BookingSummary() {
 
   return (
     <div className="summary">
-      <h2>Booking Summary</h2>
+      <h2>{t('bookingSummary.title')}</h2>
       <div className="row">
         <img src={listing.imageUrl} alt={listing.title} />
         <div>
           <h3>{listing.title}</h3>
           <div>{listing.location}</div>
-          <div>Dates: {format(checkIn,'dd MMM yyyy')} → {format(checkOut,'dd MMM yyyy')} ({nights} night{nights>1?'s':''})</div>
-          <div>Guests: {state.guests}</div>
-          <div>Price: ₹{listing.pricePerNight} × {nights} = <strong>₹{total}</strong></div>
+          <div>{t('bookingSummary.dates')}: {format(checkIn,'P',{ locale })} → {format(checkOut,'P',{ locale })} ({nights} night{nights>1?'s':''})</div>
+          <div>{t('bookingSummary.guests')}: {state.guests}</div>
+          <div>{t('bookingSummary.price')}: ₹{listing.pricePerNight} × {nights} = <strong>₹{total}</strong></div>
         </div>
       </div>
 
       <form onSubmit={onProceed} className="guest-form">
-        <label>Name<input name="name" required /></label>
-        <label>Phone<input name="phone" required /></label>
-        <label>Email<input name="email" type="email" required /></label>
-        <button className="primary" type="submit">Proceed to Pay</button>
+        <label>{t('bookingSummary.name')}<input name="name" required /></label>
+        <label>{t('bookingSummary.phone')}<input name="phone" required /></label>
+        <label>{t('bookingSummary.email')}<input name="email" type="email" required /></label>
+        <button className="primary" type="submit">{t('bookingSummary.proceed')}</button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate react-i18next with English and Spanish translations
- localize BookingSummary, ListingCard, StickyDateBar, and Header
- add language switcher and locale-aware DayPicker formatting

## Testing
- `npm test` *(fails: your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a054e5d124832b85cf67d1cb8ec5bd