### PR TITLE
feat: refine responsive styles and touch targets

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -7,6 +7,25 @@ body {
     font-family: 'Inter', sans-serif;
 }
 
+.container { max-width: 1120px; margin: 0 auto; padding: 16px; }
+
+/* Responsive base typography and spacing */
+@media (max-width: 320px) {
+  body { font-size: 14px; }
+  .container { padding: 8px; }
+}
+
+@media (min-width: 768px) {
+  body { font-size: 16px; }
+  .container { padding: 24px; }
+}
+
+@media (min-width: 1024px) {
+  body { font-size: 17px; }
+  .container { padding: 32px; }
+  .grid { gap: 24px; }
+}
+
 .site-header {
     margin-bottom: 0;
 }
@@ -26,13 +45,10 @@ body {
     margin-top: 2rem;
 }
 
-/* Layout container */
-.container { max-width: 1120px; margin: 0 auto; padding: 16px; }
-
 /* Responsive grid */
 .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
 .card { grid-column: span 12; }
-@media (min-width: 900px) {
+@media (min-width: 1024px) {
   .card--featured { grid-column: span 12; }
   .card--half { grid-column: span 6; }
 }
@@ -49,23 +65,23 @@ body {
 
 /* Controls row: date chip, guests, pill, actions */
 .lc-controls { display:grid; grid-template-columns:auto auto 1fr auto; gap:8px; align-items:center; margin-top:10px; }
-.lc-chip { height:36px; padding:0 12px; min-width:160px; border:1px solid #e5e7eb; border-radius:999px; background:#fff; }
-.lc-select { height:36px; padding:0 10px; }
+.lc-chip { min-height:44px; padding:0 12px; min-width:160px; border:1px solid #e5e7eb; border-radius:999px; background:#fff; }
+.lc-select { min-height:44px; padding:0 10px; }
 .lc-pill { padding:4px 10px; border-radius:999px; font-size:.85rem; justify-self:end; white-space:nowrap; }
 .lc-pill.muted { background:#f3f4f6; color:#6b7280; }
 .lc-pill.ok { background:#d1fae5; color:#065f46; }
 
 .lc-actions { display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end; margin-top:8px; }
-.btn-primary { height:36px; padding:0 14px; border-radius:8px; border:none; background:var(--color-primary); color:#fff; font-weight:600; }
+.btn-primary { min-height:44px; min-width:44px; padding:0 14px; border-radius:8px; border:none; background:var(--color-primary); color:#fff; font-weight:600; }
 .btn-primary:focus-visible { outline:2px solid #4F46E544; outline-offset:2px; }
 .btn-primary:disabled { opacity:.5; cursor:not-allowed; }
-.btn-dark { height:36px; padding:0 14px; border-radius:8px; border:none; background:#111827; color:#fff; font-weight:600; }
+.btn-dark { min-height:44px; min-width:44px; padding:0 14px; border-radius:8px; border:none; background:#111827; color:#fff; font-weight:600; }
 .btn-dark:focus-visible { outline:2px solid #11182744; outline-offset:2px; }
 .btn-dark:disabled { opacity:.5; cursor:not-allowed; }
-.icon-btn { width:36px; height:36px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; display:flex; align-items:center; justify-content:center; color:var(--color-primary); text-decoration:none; font-size:18px; }
+.icon-btn { min-width:44px; min-height:44px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; display:flex; align-items:center; justify-content:center; color:var(--color-primary); text-decoration:none; font-size:18px; }
 .icon-btn:hover { background:#f9fafb; }
 .icon-btn.whatsapp { color:var(--color-accent); }
-.btn-ghost { height:32px; padding:0 10px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; text-decoration:none; display:flex; align-items:center; font-size:.85rem; }
+.btn-ghost { min-height:44px; min-width:44px; padding:0 10px; border:1px solid #e5e7eb; border-radius:6px; background:#fff; text-decoration:none; display:flex; align-items:center; font-size:.85rem; }
 .btn-ghost:hover { background:#f9fafb; }
 
 .popover { position:fixed; z-index:1000; background:#fff; border:1px solid #e5e7eb; border-radius:10px; padding:8px; box-shadow:0 10px 20px rgba(0,0,0,.08); }
@@ -75,8 +91,8 @@ body {
 
 /* Sticky bar */
 .sb-wrap { position: sticky; top: 0; z-index: 20; display: flex; gap: 8px; align-items: center; padding: 10px; background: rgba(255,255,255,.9); backdrop-filter: blur(6px); border-bottom: 1px solid #eee; }
-.sb-chip { height: 36px; padding: 0 12px; min-width:160px; border: 1px solid #e5e7eb; border-radius: 999px; background: #fff; }
-.sb-select { height: 36px; padding: 0 8px; }
+.sb-chip { min-height: 44px; padding: 0 12px; min-width:160px; border: 1px solid #e5e7eb; border-radius: 999px; background: #fff; }
+.sb-select { min-height: 44px; padding: 0 8px; }
 
 /* Mobile sticky footer variant */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add base media queries for typography and spacing at 320px, 768px, and 1024px
- ensure buttons, chips, and selects meet 44px minimum touch target
- adjust grid breakpoint to 1024px and expand gaps for large screens

## Testing
- `npm test` *(fails: Cypress could not verify that the server at http://localhost:5173 is running)*

------
https://chatgpt.com/codex/tasks/task_e_68a0568dece4832bb154e52ca004fd97