### PR TITLE
Add typography scale and standardize headings

### DIFF
--- a/src/components/listings/ListingCard.jsx
+++ b/src/components/listings/ListingCard.jsx
@@ -64,7 +64,7 @@ export default function ListingCard({ listing, prefillDates, prefillGuests }) {
       </div>
       <div className="lc-body">
         <div className="lc-header">
-          <h3 className="lc-title"><Link to={`/listings/${listing.id}`}>{listing.title}</Link></h3>
+            <h2 className="lc-title"><Link to={`/listings/${listing.id}`}>{listing.title}</Link></h2>
           <div className="lc-sub">{listing.location}</div>
           <div className="lc-price">₹{listing.pricePerNight} / night</div>
         </div>

--- a/src/components/shared/EnquiryModal.jsx
+++ b/src/components/shared/EnquiryModal.jsx
@@ -61,7 +61,7 @@ export default function EnquiryModal({ onClose, listing, guests, preferredFrom, 
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
-        <h3>Enquire about {listing.title}</h3>
+          <h2>Enquire about {listing.title}</h2>
         {prefDates && <div className="muted">Preferred dates: {prefDates}</div>}
         <form onSubmit={submit} className="modal-form">
           <label>Full name<input ref={firstInput} required value={form.name} onChange={e=>setForm(f=>({...f, name:e.target.value}))} /></label>

--- a/src/pages/BookingSummary.jsx
+++ b/src/pages/BookingSummary.jsx
@@ -34,12 +34,12 @@ export default function BookingSummary() {
   };
 
   return (
-    <div className="summary">
-      <h2>Booking Summary</h2>
+      <div className="summary">
+        <h1>Booking Summary</h1>
       <div className="row">
         <img src={listing.imageUrl} alt={listing.title} />
         <div>
-          <h3>{listing.title}</h3>
+            <h2>{listing.title}</h2>
           <div>{listing.location}</div>
           <div>Dates: {format(checkIn,'dd MMM yyyy')} → {format(checkOut,'dd MMM yyyy')} ({nights} night{nights>1?'s':''})</div>
           <div>Guests: {state.guests}</div>

--- a/src/pages/GuestBooking.jsx
+++ b/src/pages/GuestBooking.jsx
@@ -56,8 +56,8 @@ const GuestBooking = () => {
     };
 
     return (
-        <div>
-            <h2>📅 Multi-Listing Booking</h2>
+         <div>
+             <h1>📅 Multi-Listing Booking</h1>
             <div className="calendar-grid">
                 <table>
                     <thead>
@@ -81,8 +81,8 @@ const GuestBooking = () => {
                     </tbody>
                 </table>
             </div>
-            <div className="summary">
-                <h3>Guest Details</h3>
+             <div className="summary">
+                 <h2>Guest Details</h2>
                 <input placeholder='Name' value={guest.name} onChange={e => setGuest({ ...guest, name: e.target.value })} />
                 <input placeholder='Phone' value={guest.phone} onChange={e => setGuest({ ...guest, phone: e.target.value })} />
                 <input placeholder='Email' value={guest.email} onChange={e => setGuest({ ...guest, email: e.target.value })} />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -15,10 +15,11 @@ export default function HomePage() {
   const others = listings.filter(l => !FEATURED_LISTING_IDS.includes(Number(l.id)));
 
   return (
-    <div className="container">
-      <StickyDateBar onSearch={handleSearch} initialDates={filters.dates} initialGuests={filters.guests} />
-      <div className="notice">Instant booking is not yet available. Submit an enquiry and we’ll confirm availability.</div>
-      <section className="grid">
+      <div className="container">
+        <StickyDateBar onSearch={handleSearch} initialDates={filters.dates} initialGuests={filters.guests} />
+        <h1>Available Listings</h1>
+        <div className="notice">Instant booking is not yet available. Submit an enquiry and we’ll confirm availability.</div>
+        <section className="grid">
         {featured.map(l => (
           <div key={`f-${l.id}`} className="card card--featured">
             <ListingCard listing={l} prefillDates={filters.dates} prefillGuests={filters.guests} />

--- a/src/pages/ListingDetails.jsx
+++ b/src/pages/ListingDetails.jsx
@@ -24,11 +24,11 @@ export default function ListingDetails() {
       <div className="lc-media">
         <img src={listing.imageUrl} alt={listing.title} />
       </div>
-      <div className="lc-body d-flex flex-column">
-        <h3 className="lc-title">{listing.title}</h3>
-        <div className="lc-sub">{listing.location}</div>
-        <div className="lc-price">₹{listing.pricePerNight} / night</div>
-      </div>
+        <div className="lc-body d-flex flex-column">
+          <h1 className="lc-title">{listing.title}</h1>
+          <div className="lc-sub">{listing.location}</div>
+          <div className="lc-price">₹{listing.pricePerNight} / night</div>
+        </div>
       {openEnquiry && (
         <EnquiryModal
           onClose={() => setOpenEnquiry(false)}

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -10,28 +10,31 @@ const Listings = () => {
         axios.get(`${API_BASE}/listings`).then(res => setListings(res.data));
     }, []);
 
-    return (
-        <div className="row">
-            {listings.map(listing => (
-                <div className="col-md-4 mb-4" key={listing.id}>
-                    <div className="card h-100">
-                        <img
-                            src="https://via.placeholder.com/400x300?text=Listing"
-                            className="card-img-top"
-                            alt={listing.name}
-                            style={{ height: '470px', objectFit: 'cover' }}
-                        />
-                        <div className="card-body d-flex flex-column">
-                            <h5 className="card-title">{listing.name}</h5>
-                            <p className="card-text">Sleeps {listing.maxGuests} guests</p>
-                            <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
-                            <button className="btn btn-danger mt-2" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
-                        </div>
-                    </div>
-                </div>
-            ))}
-        </div>
-    );
+     return (
+         <div>
+             <h1>Listings</h1>
+             <div className="row">
+                 {listings.map(listing => (
+                     <div className="col-md-4 mb-4" key={listing.id}>
+                         <div className="card h-100">
+                             <img
+                                 src="https://via.placeholder.com/400x300?text=Listing"
+                                 className="card-img-top"
+                                 alt={listing.name}
+                                 style={{ height: '470px', objectFit: 'cover' }}
+                             />
+                             <div className="card-body d-flex flex-column">
+                                 <h2 className="card-title">{listing.name}</h2>
+                                 <p className="card-text">Sleeps {listing.maxGuests} guests</p>
+                                 <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
+                                 <button className="btn btn-danger mt-2" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
+                             </div>
+                         </div>
+                     </div>
+                 ))}
+             </div>
+         </div>
+     );
 };
 
 export default Listings;

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,5 @@
+@import './styles/typography.css';
+
 :root {
     --color-primary: #4F46E5;
     --color-accent: #10B981;
@@ -5,6 +7,11 @@
 
 body {
     font-family: 'Inter', sans-serif;
+}
+
+section {
+    margin: 2rem 0;
+    padding: 1rem 0;
 }
 
 .site-header {
@@ -31,7 +38,7 @@ body {
 
 /* Responsive grid */
 .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
-.card { grid-column: span 12; }
+.card { grid-column: span 12; padding: 16px; margin-bottom: 16px; }
 @media (min-width: 900px) {
   .card--featured { grid-column: span 12; }
   .card--half { grid-column: span 6; }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,47 @@
+/* Typography Scale */
+h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin: 0 0 0.5em;
+}
+
+h2 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  margin: 0 0 0.5em;
+}
+
+h3 {
+  font-size: 1.25rem;
+  line-height: 1.4;
+  margin: 0 0 0.5em;
+}
+
+h4 {
+  font-size: 1.125rem;
+  line-height: 1.45;
+  margin: 0 0 0.5em;
+}
+
+h5 {
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 0.5em;
+}
+
+h6 {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0 0 0.5em;
+}
+
+body {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.caption {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: #6b7280;
+}


### PR DESCRIPTION
## Summary
- Define typographic scale and import into global styles
- Normalize section and card spacing for consistent layout
- Reorder page templates to use logical heading hierarchy

## Testing
- `npm test` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a0568c47f8832ba95087f93b93cdb4