### PR TITLE
Improve contrast for buttons and status pill

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -135,7 +135,7 @@ const Home = () => {
             <p style={{ fontSize: '0.95rem', color: '#555' }}>{listing.desc}</p>
             <button
               className="btn btn-danger"
-              style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F', marginTop: 'auto' }}
+              style={{ backgroundColor: '#D32F2F', borderColor: '#D32F2F', marginTop: 'auto' }}
             >
               Reserve
             </button>

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -25,7 +25,7 @@ const Listings = () => {
                             <h5 className="card-title">{listing.name}</h5>
                             <p className="card-text">Sleeps {listing.maxGuests} guests</p>
                             <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
-                            <button className="btn btn-danger mt-2" style={{ backgroundColor: '#FF5A5F', borderColor: '#FF5A5F' }}>Reserve</button>
+                            <button className="btn btn-danger mt-2" style={{ backgroundColor: '#D32F2F', borderColor: '#D32F2F' }}>Reserve</button>
                         </div>
                     </div>
                 </div>

--- a/src/style.css
+++ b/src/style.css
@@ -52,7 +52,7 @@ body {
 .lc-chip { height:36px; padding:0 12px; min-width:160px; border:1px solid #e5e7eb; border-radius:999px; background:#fff; }
 .lc-select { height:36px; padding:0 10px; }
 .lc-pill { padding:4px 10px; border-radius:999px; font-size:.85rem; justify-self:end; white-space:nowrap; }
-.lc-pill.muted { background:#f3f4f6; color:#6b7280; }
+.lc-pill.muted { background:#f6f7f9; color:#6b7280; }
 .lc-pill.ok { background:#d1fae5; color:#065f46; }
 
 .lc-actions { display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end; margin-top:8px; }
@@ -89,7 +89,7 @@ body {
 }
 
 .primary {
-  background: #ff5a5f;
+  background: #d32f2f;
   color: #fff;
   border: none;
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- darken primary action buttons to meet WCAG AA contrast
- lighten muted status pill background for accessible text

## Testing
- `npx pa11y --config pa11y.json http://localhost:5173` *(fails: missing anchors and form labels, no color contrast errors)*
- `npm test` *(fails: no spec files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a056896684832b939fb8d040e99395