### PR TITLE
Handle availability fetch errors

### DIFF
--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -1,6 +1,21 @@
 import api from './api';
 
+/**
+ * Fetch availability data for a listing. The API is expected to return an
+ * array of ISO date strings or ranges. If the request fails or the response is
+ * not in the expected format, an empty array is returned instead.
+ *
+ * @param {string|number} listingId Identifier of the listing
+ * @returns {Promise<Array>} Availability information
+ */
 export async function fetchAvailability(listingId) {
-  const res = await api.get(`/listings/${listingId}/availability`);
-  return res.data; // expecting array of ISO date strings or ranges
+  if (!listingId) return [];
+  try {
+    const res = await api.get(`/listings/${listingId}/availability`);
+    return Array.isArray(res.data) ? res.data : [];
+  } catch (err) {
+    // Network or server errors are silently ignored upstream, so just return
+    // an empty array to avoid breaking the UI.
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- handle missing listing ID and API failures in availability fetch
- document and guard against invalid availability responses

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a093c751cc832b9f15580f9c100240