### PR TITLE
Add robust Listings page with API guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # Base URL for backend API
-VITE_API_BASE_URL=http://localhost:5000
+VITE_API_BASE_URL=https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsites.net

--- a/src/components/listings/ListingGrid.tsx
+++ b/src/components/listings/ListingGrid.tsx
@@ -1,0 +1,15 @@
+import ListingCard from './ListingCard';
+
+interface Props {
+  items: any[];
+}
+
+export default function ListingGrid({ items }: Props) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {items.map(item => (
+        <ListingCard key={item.id} listing={item} />
+      ))}
+    </div>
+  );
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,2 @@
+declare const VITE_API_BASE_URL: string | undefined;
+export {};

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,18 @@
+export function getApiBase() {
+  const v = import.meta.env.VITE_API_BASE_URL as string | undefined;
+  if (!v || !/^https?:\/\//.test(v)) {
+    console.error('[ENV] Invalid VITE_API_BASE_URL', v);
+    return '';
+  }
+  return v.replace(/\/+$/, '');
+}
+
+export async function fetchJson<T>(path: string): Promise<T> {
+  const base = getApiBase();
+  if (!base) throw new Error('API base URL missing');
+  const res = await fetch(`${base}${path}`, {
+    headers: { Accept: 'application/json' }
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}

--- a/src/pages/ListingsPage.tsx
+++ b/src/pages/ListingsPage.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import ListingGrid from '@/components/listings/ListingGrid';
+import { getApiBase, fetchJson } from '@/lib/http';
+
+export default function ListingsPage() {
+  const [rows, setRows] = useState<any[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    const base = getApiBase();
+    console.debug('[Listings] mount', { base });
+    fetchJson<any[]>('/api/listings/public')
+      .then(d => {
+        console.debug('[Listings] fetched', { count: d?.length ?? 0 });
+        setRows(d);
+      })
+      .catch(e => {
+        console.error('[Listings] fetch failed', e);
+        setErr('Could not load listings. Please try again.');
+      });
+  }, []);
+
+  if (err) return <div className="alert alert-danger">{err}</div>;
+  if (rows === null) return <div>Loading listings…</div>;
+  if (rows.length === 0) return <div>No listings published yet.</div>;
+  return <ListingGrid items={rows} />;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,12 +1,11 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Header from './components/chrome/Header';
 import Footer from './components/chrome/Footer';
-import HomePage from './pages/HomePage';
+import ListingsPage from '@/pages/ListingsPage';
 import ListingDetails from './pages/ListingDetails';
 import GuestBooking from './pages/GuestBooking';
 import BookingSummary from './pages/BookingSummary';
 import BookingConfirmation from './pages/BookingConfirmation';
-import Listings from './pages/Listings';
 import SafetyProtocols from './pages/SafetyProtocols';
 
 export default function AppRoutes() {
@@ -14,8 +13,8 @@ export default function AppRoutes() {
     <>
       <Header />
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/listings" element={<Listings />} />
+        <Route path="/" element={<Navigate to="/listings" replace />} />
+        <Route path="/listings" element={<ListingsPage />} />
         <Route path="/listings/:id" element={<ListingDetails />} />
         <Route path="/guest-booking" element={<GuestBooking />} />
         <Route path="/booking/summary" element={<BookingSummary />} />

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
     base: './',
     plugins: [react()],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, 'src')
+        }
+    },
     test: {
         environment: 'jsdom',
         setupFiles: './src/test/setup.ts',


### PR DESCRIPTION
## Summary
- redirect root to Listings and mount new `ListingsPage`
- add HTTP helper with env validation and user-facing errors
- document `VITE_API_BASE_URL` and add ListingGrid component

## Testing
- `npm test` *(fails: Cannot find module '/workspace/atlas-guest-portal/node_modules/cypress/bin/cypress.js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa41eb6a8c832ba5a47a16da186f6e